### PR TITLE
feat: Make the dropzone unique by default

### DIFF
--- a/resources/views/livewire/dropzone.blade.php
+++ b/resources/views/livewire/dropzone.blade.php
@@ -154,7 +154,7 @@
                 },
                 removeUpload(tmpFilename) {
                     // Dispatch an event to remove the temporarily uploaded file
-                    _this.dispatch('{{ $name }}:fileRemoved', { tmpFilename })
+                    _this.dispatch('{{ $uuid }}:fileRemoved', { tmpFilename })
                 },
             });
         })

--- a/src/Http/Livewire/Dropzone.php
+++ b/src/Http/Livewire/Dropzone.php
@@ -3,6 +3,7 @@
 namespace Dasundev\LivewireDropzone\Http\Livewire;
 
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Locked;
@@ -22,9 +23,10 @@ class Dropzone extends Component
     #[Locked]
     public array $rules;
 
-    public $upload;
+    #[Locked]
+    public string $uuid;
 
-    public string $name;
+    public $upload;
 
     public string $error;
 
@@ -39,9 +41,9 @@ class Dropzone extends Component
         ];
     }
 
-    public function mount(string $name, array $rules = [], bool $multiple = false): void
+    public function mount(array $rules = [], bool $multiple = false): void
     {
-        $this->name = $name;
+        $this->uuid = Str::uuid();
         $this->multiple = $multiple;
         $this->rules = $rules;
     }
@@ -54,7 +56,7 @@ class Dropzone extends Component
             $this->validate();
         } catch (ValidationException $e) {
             // If the upload validation fails, we trigger the following event
-            $this->dispatch("{$this->name}:uploadError", $e->getMessage());
+            $this->dispatch("{$this->uuid}:uploadError", $e->getMessage());
 
             return;
         }
@@ -75,7 +77,7 @@ class Dropzone extends Component
      */
     public function handleUpload(TemporaryUploadedFile $file): void
     {
-        $this->dispatch("{$this->name}:fileAdded", [
+        $this->dispatch("{$this->uuid}:fileAdded", [
             'tmpFilename' => $file->getFilename(),
             'name' => $file->getClientOriginalName(),
             'extension' => $file->extension(),
@@ -88,7 +90,7 @@ class Dropzone extends Component
     /**
      * Handle the file added event.
      */
-    #[On('{name}:fileAdded')]
+    #[On('{uuid}:fileAdded')]
     public function onFileAdded(array $file): void
     {
         $this->files[] = $file;
@@ -97,7 +99,7 @@ class Dropzone extends Component
     /**
      * Handle the file removal event.
      */
-    #[On('{name}:fileRemoved')]
+    #[On('{uuid}:fileRemoved')]
     public function onFileRemoved(string $tmpFilename): void
     {
         $this->files = array_filter($this->files, function ($file) use ($tmpFilename) {
@@ -114,7 +116,7 @@ class Dropzone extends Component
     /**
      * Handle the upload error event.
      */
-    #[On('{name}:uploadError')]
+    #[On('{uuid}:uploadError')]
     public function onUploadError(string $error): void
     {
         $this->error = $error;

--- a/tests/Feature/DropzoneTest.php
+++ b/tests/Feature/DropzoneTest.php
@@ -4,22 +4,26 @@ use Dasundev\LivewireDropzone\Http\Livewire\Dropzone;
 use Illuminate\Http\UploadedFile;
 
 it('renders successfully', function () {
-    Livewire\Livewire::test(Dropzone::class, ['name' => 'foo'])
+    Livewire\Livewire::test(Dropzone::class)
         ->assertOk();
 });
 
 it('accepts and sets rules parameter correctly', function () {
-    Livewire\Livewire::test(Dropzone::class, ['name' => 'foo', 'rules' => ['image,mimes:png,jpeg']])
+    Livewire\Livewire::test(Dropzone::class, ['rules' => ['image,mimes:png,jpeg']])
         ->assertSet('rules', ['image,mimes:png,jpeg']);
 });
 
 it('accepts and sets multiple parameter correctly', function () {
-    Livewire\Livewire::test(Dropzone::class, ['name' => 'foo', 'multiple' => true])
+    Livewire\Livewire::test(Dropzone::class, ['multiple' => true])
         ->assertSet('multiple', true);
 });
 
 it('can upload file', function () {
-    Livewire\Livewire::test(Dropzone::class, ['name' => 'foo'])
+    $dropzone = Livewire\Livewire::test(Dropzone::class);
+
+    $uuid = $dropzone->get('uuid');
+
+    $dropzone
         ->set('upload', UploadedFile::fake()->image('foo.png'))
-        ->assertDispatched('foo:fileAdded');
+        ->assertDispatched("$uuid:fileAdded");
 });


### PR DESCRIPTION
Previously, the user was required to provide a name for the dropzone component, but it is no longer necessary. I have implemented `Str::uuid()` to ensure the component is unique by default.