### PR TITLE
fix: Only allow a single file when the "multiple" variable is set to false

### DIFF
--- a/src/Http/Livewire/Dropzone.php
+++ b/src/Http/Livewire/Dropzone.php
@@ -93,7 +93,7 @@ class Dropzone extends Component
     #[On('{uuid}:fileAdded')]
     public function onFileAdded(array $file): void
     {
-        $this->files[] = $file;
+        $this->files = $this->multiple ? array_merge($this->files, [$file]) : [$file];
     }
 
     /**


### PR DESCRIPTION
Hey,

I've been using your code in my project and it's exactly what I was looking for to set up a dropzone but I noticed a little quirk. 

Even when I switch off the multiple mode, every time I add a file, it gets bundled up with the others and displayed together. Ideally, with multiple set to false, I'd expect only one file to be allowed at a time, making the variable consistently hold just one element.

If the multiple setting is meant for a frontend feature like selecting multiple items, consider capping it for individual images or
maybe adding a new variable like maxFiles.