### PR TITLE
fix: Assign an initial value to the $file property.

### DIFF
--- a/src/Http/Livewire/Dropzone.php
+++ b/src/Http/Livewire/Dropzone.php
@@ -18,7 +18,7 @@ class Dropzone extends Component
     use WithFileUploads;
 
     #[Modelable]
-    public array $files;
+    public ?array $files = [];
 
     #[Locked]
     public array $rules;

--- a/src/Http/Livewire/Dropzone.php
+++ b/src/Http/Livewire/Dropzone.php
@@ -18,7 +18,7 @@ class Dropzone extends Component
     use WithFileUploads;
 
     #[Modelable]
-    public ?array $files = [];
+    public ?array $files;
 
     #[Locked]
     public array $rules;
@@ -46,6 +46,7 @@ class Dropzone extends Component
         $this->uuid = Str::uuid();
         $this->multiple = $multiple;
         $this->rules = $rules;
+        $this->files = [];
     }
 
     public function updatedUpload(): void


### PR DESCRIPTION
When I initially tried to use the package, I experienced this error, so I tried to assign an initial value to the `$files` variable and works. 😃 

![Screenshot 2024-02-26 at 17 58 31](https://github.com/dasundev/livewire-dropzone/assets/16547271/64c6586a-bace-4724-b976-af32ab010fe0)
