### PR TITLE
fix: add use the number helper class in component

### DIFF
--- a/resources/views/livewire/dropzone.blade.php
+++ b/resources/views/livewire/dropzone.blade.php
@@ -1,3 +1,5 @@
+@use('Illuminate\Support\Number')
+
 <div
     x-cloak
     x-data="dropzone({


### PR DESCRIPTION
After publishing the component view, trying to use it failed, pointing to the lack of import of the Number helper class.

![Screenshot 2024-02-26 at 18 04 08](https://github.com/dasundev/livewire-dropzone/assets/16547271/2fff57e9-01a5-46c5-b7da-9dd62c69af61)
