### PR TITLE
fix: the the $files is not countable

### DIFF
--- a/resources/views/livewire/dropzone.blade.php
+++ b/resources/views/livewire/dropzone.blade.php
@@ -81,7 +81,7 @@
         </div>
 
 
-        @if(count($files) > 0)
+        @if(!!$files && count($files) > 0)
             <div class="dz-flex dz-flex-wrap dz-gap-x-10 dz-gap-y-2 dz-justify-start dz-w-full dz-mt-5">
                 @foreach($files as $file)
                     <div class="dz-flex dz-items-center dz-justify-between dz-gap-2 dz-border dz-rounded dz-border-gray-200 dz-w-full dz-h-auto dz-overflow-hidden dark:dz-border-gray-700">


### PR DESCRIPTION
when using nested livewire or livewire inside laravel component  refreshing part of the page the error appears that the files is not countable