### PR TITLE
fix: Handle the file removal event without manually deleting temporary files

### DIFF
--- a/src/Http/Livewire/Dropzone.php
+++ b/src/Http/Livewire/Dropzone.php
@@ -104,13 +104,11 @@ class Dropzone extends Component
     public function onFileRemoved(string $tmpFilename): void
     {
         $this->files = array_filter($this->files, function ($file) use ($tmpFilename) {
-            $isNotTmpFilename = $file['tmpFilename'] !== $tmpFilename;
-
-            if (! $isNotTmpFilename) {
-                unlink($file['path']);
-            }
-
-            return $isNotTmpFilename;
+            // Remove the temporary file from the array only.
+            // No need to remove from the Livewire's temporary upload directory manually.
+            // Because, files older than 24 hours cleanup automatically by Livewire.
+            // For more details, refer to: https://livewire.laravel.com/docs/uploads#configuring-automatic-file-cleanup
+            return $file['tmpFilename'] !== $tmpFilename;
         });
     }
 


### PR DESCRIPTION
No need to remove temporary file from the Livewire's temporary upload directory manually. because, files older than 24 hours cleanup automatically by Livewire.

**NOTE:** If you are using S3 as the `temporary_file_upload ` disk. you should run the following command:

```bash
php artisan livewire:configure-s3-upload-cleanup
```

For more details, refer to: https://livewire.laravel.com/docs/uploads#configuring-automatic-file-cleanup

Closes #20 