### PR TITLE
Fix: remember files after validation error on the form

### DIFF
--- a/src/Http/Livewire/Dropzone.php
+++ b/src/Http/Livewire/Dropzone.php
@@ -41,12 +41,12 @@ class Dropzone extends Component
         ];
     }
 
-    public function mount(array $rules = [], bool $multiple = false): void
+    public function mount(array $rules = [], bool $multiple = false, array $files = []): void
     {
         $this->uuid = Str::uuid();
         $this->multiple = $multiple;
         $this->rules = $rules;
-        $this->files = [];
+        $this->files = $files;
     }
 
     public function updatedUpload(): void

--- a/tests/Feature/DropzoneTest.php
+++ b/tests/Feature/DropzoneTest.php
@@ -18,6 +18,34 @@ it('accepts and sets multiple parameter correctly', function () {
         ->assertSet('multiple', true);
 });
 
+it('accepts and sets files parameter correctly', function () {
+    $file1 = UploadedFile::fake()->image('file1.png');
+    $file2 = UploadedFile::fake()->image('file2.jpg');
+
+    $files = [
+        [
+            'name' => $file1->getClientOriginalName(),
+            'path' => $file1->path(),
+            'extension' => $file1->extension(),
+            'temporaryUrl' => $file1->path(),
+            'size' => $file1->getSize(),
+            'tmpFilename' => $file1->getFilename(),
+        ],
+        [
+            'name' => $file2->getClientOriginalName(),
+            'path' => $file2->path(),
+            'extension' => $file2->extension(),
+            'temporaryUrl' => $file2->path(),
+            'size' => $file2->getSize(),
+            'tmpFilename' => $file2->getFilename(),
+        ],
+    ];
+
+    Livewire\Livewire::test(Dropzone::class, ['files' => $files])
+        ->assertSet('files', $files);
+});
+
+
 it('can upload file', function () {
     $dropzone = Livewire\Livewire::test(Dropzone::class);
 


### PR DESCRIPTION
Remember the files after validation error occur on any field. We can use the parameter files to pass the already uploaded files.

This will fix the issue No. #61 